### PR TITLE
[FEAT] 로그아웃 API 구현

### DIFF
--- a/side/src/main/java/com/ssafy/side/api/auth/controller/AuthController.java
+++ b/side/src/main/java/com/ssafy/side/api/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.ssafy.side.api.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -51,6 +52,15 @@ public class AuthController {
     public ResponseEntity<LoginAccessTokenDto> reissueToken(HttpServletRequest request) {
         String accessToken = (String) request.getAttribute("newAccessToken");
         return ResponseEntity.status(HttpStatus.CREATED).body(new LoginAccessTokenDto(accessToken));
+    }
+
+    @PostMapping("/logout")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(description = "로그아웃 API 입니다.")
+    public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = (String) request.getAttribute("refreshToken");
+        authService.logout(refreshToken, request, response);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
 }

--- a/side/src/main/java/com/ssafy/side/api/auth/service/AuthService.java
+++ b/side/src/main/java/com/ssafy/side/api/auth/service/AuthService.java
@@ -2,9 +2,12 @@ package com.ssafy.side.api.auth.service;
 
 import com.ssafy.side.api.auth.dto.SocialLoginRequestDto;
 import com.ssafy.side.api.auth.dto.SocialLoginResponseDto;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
 
     SocialLoginResponseDto socialLogin(SocialLoginRequestDto requestDto);
+    void logout(String refreshToken, HttpServletRequest request, HttpServletResponse response);
 
 }

--- a/side/src/main/java/com/ssafy/side/api/auth/service/Impl/AuthServiceImplWithKakao.java
+++ b/side/src/main/java/com/ssafy/side/api/auth/service/Impl/AuthServiceImplWithKakao.java
@@ -11,6 +11,9 @@ import com.ssafy.side.api.member.domain.Member;
 import com.ssafy.side.api.member.domain.MemberRepository;
 import com.ssafy.side.common.config.jwt.JwtTokenProvider;
 import com.ssafy.side.common.exception.BadRequestException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -58,6 +61,22 @@ public class AuthServiceImplWithKakao implements AuthService {
 
         } catch (IllegalArgumentException ex) {
             throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    @Transactional
+    public void logout(String refreshToken, HttpServletRequest request, HttpServletResponse response) {
+        Member member = memberRepository.findByRefreshTokenOrThrow(refreshToken);
+        member.updateRefreshToken(null);
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                cookie.setMaxAge(0);
+                cookie.setValue(null);
+                cookie.setPath("/");
+                response.addCookie(cookie);
+            }
         }
     }
 }

--- a/side/src/main/java/com/ssafy/side/api/auth/service/KakaoAuthService.java
+++ b/side/src/main/java/com/ssafy/side/api/auth/service/KakaoAuthService.java
@@ -18,7 +18,7 @@ public class KakaoAuthService {
     @Value(value="${kakao.clientId}")
     private String clientId;
 
-    @Value(value = "${kakao.redirect-uri}")
+    @Value(value = "${kakao.redirect-uri-dev}")
     private String redirectUri;
 
     private static final String GRANT_TYPE = "authorization_code";

--- a/side/src/main/java/com/ssafy/side/common/Filter/JwtAuthenticationFilter.java
+++ b/side/src/main/java/com/ssafy/side/common/Filter/JwtAuthenticationFilter.java
@@ -1,10 +1,6 @@
 package com.ssafy.side.common.Filter;
 
-import static com.ssafy.side.common.exception.ErrorMessage.ERR_ACCESS_TOKEN_EXPIRED;
-import static com.ssafy.side.common.exception.ErrorMessage.ERR_NO_COOKIE;
-import static com.ssafy.side.common.exception.ErrorMessage.ERR_NO_REFRESH_TOKEN_IN_COOKIE;
-import static com.ssafy.side.common.exception.ErrorMessage.ERR_REFRESH_TOKEN_EXPIRED;
-import static com.ssafy.side.common.exception.ErrorMessage.ERR_UNAUTORIZED;
+import static com.ssafy.side.common.exception.ErrorMessage.*;
 
 import com.ssafy.side.common.config.jwt.JwtAuthenticationEntryPoint;
 import com.ssafy.side.common.config.jwt.JwtExceptionType;
@@ -19,7 +15,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
@@ -35,62 +30,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     private static final String ISSUE_TOKEN_API_URL = "/auth/reissue";
+    private static final String LOGOUT_API_URL = "/auth/logout";
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-                                    FilterChain chain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
         try {
             String accessToken = jwtTokenProvider.resolveToken(request);
-            /**
-             *  토큰 재발급 로직
-             */
+
             if (ISSUE_TOKEN_API_URL.equals(request.getRequestURI())) {
-                Cookie[] cookies = request.getCookies();
-                if (cookies == null) {
-                    throw new UnAuthorizedException(ERR_NO_COOKIE);
-                }
-                Optional<String> refreshToken = Arrays.stream(cookies)
-                        .filter(cookie -> "refreshToken".equals(cookie.getName()))
-                        .map(Cookie::getValue)
-                        .findFirst();
-
-                if (refreshToken.isEmpty()) {
-                    throw new UnAuthorizedException(ERR_NO_REFRESH_TOKEN_IN_COOKIE);
-                }
-
-                // 토큰이 없을 때
-                if (jwtTokenProvider.validateToken(refreshToken.get()) == JwtExceptionType.EMPTY_JWT) {
-                    throw new UnAuthorizedException(ERR_UNAUTORIZED);
-                }
-
-                // access, refresh 둘 다 만료
-                if (jwtTokenProvider.validateToken(refreshToken.get()) == JwtExceptionType.EXPIRED_JWT_TOKEN) {
-                    throw new UnAuthorizedException(ERR_REFRESH_TOKEN_EXPIRED);
-                }
-
-                // 토큰 재발급
-                Long memberId = jwtTokenProvider.validateMemberRefreshToken(refreshToken.get());
-
-                String newAccessToken = jwtTokenProvider.generateAccessToken(memberId);
-
-                setAuthentication(newAccessToken);
-                request.setAttribute("newAccessToken", newAccessToken);
-            }
-
-            /**
-             * 토큰 검증 로직
-             */
-            else {
-                if (accessToken != null) {
-                    // 토큰 검증
-                    JwtExceptionType jwtException = jwtTokenProvider.validateToken(accessToken);
-                    if (jwtException == JwtExceptionType.VALID_JWT_TOKEN) {
-                        setAuthentication(accessToken);
-                    }
-                    else if (jwtException == JwtExceptionType.EXPIRED_JWT_TOKEN){
-                        throw new UnAuthorizedException(ERR_ACCESS_TOKEN_EXPIRED);
-                    }
-                }
+                handleTokenReissue(request);
+            } else if (LOGOUT_API_URL.equals(request.getRequestURI())) {
+                handleLogout(request, response);
+            } else {
+                validateAccessToken(accessToken);
             }
         } catch (UnAuthorizedException e) {
             jwtAuthenticationEntryPoint.setResponse(response, HttpStatus.UNAUTHORIZED, e.getCode().toString());
@@ -100,10 +53,60 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         chain.doFilter(request, response);
     }
 
+    private void handleTokenReissue(HttpServletRequest request) {
+        String refreshToken = getRefreshTokenFromCookies(request);
+        validateRefreshToken(refreshToken);
+
+        Long memberId = jwtTokenProvider.validateMemberRefreshToken(refreshToken);
+        String newAccessToken = jwtTokenProvider.generateAccessToken(memberId);
+
+        setAuthentication(newAccessToken);
+        request.setAttribute("newAccessToken", newAccessToken);
+    }
+
+    private void handleLogout(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = getRefreshTokenFromCookies(request);
+        validateRefreshToken(refreshToken);
+
+        request.setAttribute("refreshToken", refreshToken);
+    }
+
+    private String getRefreshTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            throw new UnAuthorizedException(ERR_NO_COOKIE);
+        }
+        return Arrays.stream(cookies)
+                .filter(cookie -> "refreshToken".equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElseThrow(() -> new UnAuthorizedException(ERR_NO_REFRESH_TOKEN_IN_COOKIE));
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+        JwtExceptionType jwtException = jwtTokenProvider.validateToken(refreshToken);
+        if (jwtException == JwtExceptionType.EMPTY_JWT) {
+            throw new UnAuthorizedException(ERR_UNAUTORIZED);
+        }
+        if (jwtException == JwtExceptionType.EXPIRED_JWT_TOKEN) {
+            throw new UnAuthorizedException(ERR_REFRESH_TOKEN_EXPIRED);
+        }
+    }
+
+    private void validateAccessToken(String accessToken) {
+        if (accessToken != null) {
+            JwtExceptionType jwtException = jwtTokenProvider.validateToken(accessToken);
+            if (jwtException == JwtExceptionType.VALID_JWT_TOKEN) {
+                setAuthentication(accessToken);
+            } else if (jwtException == JwtExceptionType.EXPIRED_JWT_TOKEN) {
+                throw new UnAuthorizedException(ERR_ACCESS_TOKEN_EXPIRED);
+            }
+        }
+    }
+
     private void setAuthentication(String token) {
         Claims claims = jwtTokenProvider.getAccessTokenPayload(token);
-        Authentication authentication = new UserAuthentication(Long.valueOf(String.valueOf(claims.get("id"))), null,
-                null);
+        Authentication authentication = new UserAuthentication(Long.valueOf(String.valueOf(claims.get("id"))), null, null);
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #7 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 로그아웃 API를 개발했습니다.
- 현재 쿠키에 리프레시 토큰을 넣어주고 있기 때문에, 쿠키 없애는 로직과 DB에 저장해둔 리프레시 토큰을 미는 로직을 작성했습니다.
- 추후 리프레시 토큰을 DB가 아닌, 레디스를 통해 관리하는 방식으로 리팩토링할 예정입니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
